### PR TITLE
Use array slicing to calc ddim timesteps

### DIFF
--- a/ldm/modules/diffusionmodules/util.py
+++ b/ldm/modules/diffusionmodules/util.py
@@ -65,8 +65,10 @@ def make_ddim_timesteps(
     if ddim_discr_method == 'uniform':
         c = num_ddpm_timesteps // num_ddim_timesteps
         if c < 1:
-          c = 1
-        ddim_timesteps = (np.arange(0, num_ddim_timesteps) * c).astype(int)
+            c = 1
+        
+        # remove 1 final step to prevent index out of bound error
+        ddim_timesteps = np.asarray(list(range(0, num_ddpm_timesteps, c)))[:-1]
     elif ddim_discr_method == 'quad':
         ddim_timesteps = (
             (
@@ -84,7 +86,6 @@ def make_ddim_timesteps(
     # assert ddim_timesteps.shape[0] == num_ddim_timesteps
     # add one to get the final alpha values right (the ones from first scale to data during sampling)
     steps_out = ddim_timesteps + 1
-    # steps_out = ddim_timesteps
 
     if verbose:
         print(f'Selected timesteps for ddim sampler: {steps_out}')


### PR DESCRIPTION
Use array slicing instead of `np.arrange` to calculate `ddim_timesteps`. The new implementation provides better readability and performance (I have bench-marked both methods with `timeit` module and the array slicing method is slightly faster).